### PR TITLE
Update meta.yml for version 0.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ Package license: MIT
 
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/jenkspy-feedstock/blob/main/LICENSE.txt)
 
-Summary: Compute Natural Breaks (Jenks algorythm)
+Summary: Compute Natural Breaks (Fisher-Jenks algorithm)
 
 Development: https://github.com/mthh/jenkspy
 
-Compute natural break values (Jenks algorythm) on list/tuple/numpy.ndarray of integers/floats.
+Compute natural breaks (Fisher-Jenks algorithm) on list/tuple/array/numpy.ndarray of integers/floats.
 
 Current build status
 ====================

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "jenkspy" %}
-{% set version = "0.3.0" %}
+{% set version = "0.3.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 77b1f1c1fa65b397fe6fea60d458c5af02473dd3f0453a261dc2fd6ef0ffc713
+  sha256: d592dd5b459b3af6e88e533551a1628c7cff5386e310837a584e1b15648080e1
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "jenkspy" %}
-{% set version = "0.2.4" %}
+{% set version = "0.3.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: c0ca722b940b4c097207b20290994fabdd8dda05c09ff40198de78f9109fbb26
+  sha256: 77b1f1c1fa65b397fe6fea60d458c5af02473dd3f0453a261dc2fd6ef0ffc713
 
 build:
   number: 0
@@ -23,6 +23,7 @@ requirements:
     - pip
   run:
     - python
+    - numpy
 
 test:
   requires:
@@ -37,8 +38,8 @@ about:
   license: MIT
   license_family: MIT
   license_file: LICENSE
-  summary: Compute Natural Breaks (Jenks algorythm)
-  description: Compute natural break values (Jenks algorythm) on list/tuple/numpy.ndarray of integers/floats.
+  summary: Compute Natural Breaks (Fisher-Jenks algorithm)
+  description: Compute natural breaks (Fisher-Jenks algorithm) on list/tuple/array/numpy.ndarray of integers/floats.
   dev_url: https://github.com/mthh/jenkspy
 
 extra:


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

This PR replaces and should close #17 and should close #20 by adding the missing dependency (numpy) and bumping the version number to `0.3.1`.

I also modified the description in the `README.md` and in the `meta.yml` files to match the new one on PyPI (and because the current one contained a typo).